### PR TITLE
antibody.py: cut of second half of light chain was too early

### DIFF
--- a/antibody/antibody.py
+++ b/antibody/antibody.py
@@ -394,7 +394,7 @@ def safelen(seq):
 def IdentifyCDRs(light_chain, heavy_chain):
     ''' Identift CDR region and return them as dict with keys: 'FR_H1', 'FR_H2', 'FR_H3', 'FR_H4', 'FR_L1', 'FR_L2', 'FR_L3', 'FR_L4', 'H1', 'H2', 'H3', 'L1', 'L2', 'L3'
     '''
-    light_first, light_second = (light_chain[:65], light_chain[50:50+75]) if len(light_chain) > 120 else (light_chain[:60], light_chain[50:])
+    light_first, light_second = (light_chain[:65], light_chain[50:50+80]) if len(light_chain) > 130 else (light_chain[:60], light_chain[50:])
     heavy_first, heavy_second = (heavy_chain[:70], heavy_chain[50:50+95]) if len(heavy_chain) > 140 else (heavy_chain[:60], heavy_chain[50:])
 
     # L1


### PR DESCRIPTION
The length of the sequence causing an issue was 132. 
The "50+75" would exceed the length of the sequence length for lengths between 121 and 124. It should hence be ">125". Now, finding a motif so late in the sequence, the 5 should be added to both what is after the ">" and what comes after the "`+".
