### PR TITLE
antibody.py: simplifying split H/L chains first second

### DIFF
--- a/antibody/antibody.py
+++ b/antibody/antibody.py
@@ -394,8 +394,8 @@ def safelen(seq):
 def IdentifyCDRs(light_chain, heavy_chain):
     ''' Identift CDR region and return them as dict with keys: 'FR_H1', 'FR_H2', 'FR_H3', 'FR_H4', 'FR_L1', 'FR_L2', 'FR_L3', 'FR_L4', 'H1', 'H2', 'H3', 'L1', 'L2', 'L3'
     '''
-    light_first, light_second = (light_chain[:65], light_chain[50:50+80]) if len(light_chain) > 130 else (light_chain[:60], light_chain[50:])
-    heavy_first, heavy_second = (heavy_chain[:70], heavy_chain[50:50+95]) if len(heavy_chain) > 140 else (heavy_chain[:60], heavy_chain[50:])
+    light_first, light_second = (light_chain[:65], light_chain[50:50+80])
+    heavy_first, heavy_second = (heavy_chain[:70], heavy_chain[50:50+95])
 
     # L1
     res = re.search( r'C[A-Z]{1,17}(WYL|WLQ|WFQ|WYQ|WYH|WVQ|WVR|WWQ|WVK|WYR|WLL|WFL|WVF|WIQ|WYR|WNQ|WHL|WHQ|WYM|WYY)', light_first)


### PR DESCRIPTION
This pull request comprises two commits, of which the first (https://github.com/RosettaCommons/tools/commit/ddd3f1b0f0dfd6cefab3e9f7af7b87c3d07af5f3) is meant to be addressed by @lyskov in the separate pull request https://github.com/RosettaCommons/tools/pull/13 .  The motivation of this addition lies in the observation that it is absolutely fine to request a substring that exceeds the length of the sequence

<pre>
In [1]: a="ABCDEFGHIJKLMNOPQRST"
In [2]: a[4:100]
Out[2]: 'EFGHIJKLMNOPQRST'
</pre>

which eliminates the technical need for the if construct and is closer to the semantics of "we expect the motifs for L3/H3 within the next 75/80/whatever residues".
