### PR TITLE
antibody/chothia_mapping_v2.pl now "use(s) strict;"

### DIFF
--- a/antibody/chothia_mapping_v2.pl
+++ b/antibody/chothia_mapping_v2.pl
@@ -1,4 +1,6 @@
-#!/usr/bin/perl
+#!/usr/bin/perl -w
+
+use strict;
 
 if ( @ARGV < 1 ) {
 	print "Not enough arguments. Exiting...
@@ -14,17 +16,38 @@ if ( @ARGV < 1 ) {
 	die () ;
 }
 
-%threetoone=("ALA",A,"CYS",C,"ASP",D,"GLU",E,"PHE",F,"GLY",G,"HIS",H,"ILE",I,"LYS",K,"LEU",L,"MET",M,"ASN",N,"PRO",P,"GLN",Q,"ARG",R,"SER",S,"THR",T,"VAL",V,"TRP",W,"TYR",Y);
+my %threetoone=("ALA","A","CYS","C","ASP","D","GLU","E","PHE","F","GLY","G","HIS","H","ILE","I","LYS","K","LEU","L","MET","M",
+                "ASN","N","PRO","P","GLN","Q","ARG","R","SER","S","THR","T","VAL","V","TRP","W","TYR","Y");
+# dead code
+#my $l1std=11;
+#my $l2std=7;
+#my $l3std=9;
+#my $h1std=10;
+#my $h2std=16;
+#my $h3std=8;
 
-$l1std=11;
-$l2std=7;
-$l3std=9;
-$h1std=10;
-$h2std=16;
-$h3std=8;
+my ($lenl1,$lenl2,$lenl3,$lenh1,$lenh2,$lenh3);
+my ($lenfrl1,$lenfrl2,$lenfrl3,$lenfrl4,$lenfrh1,$lenfrh2,$lenfrh3,$lenfrh4);
+my ($frl1,$frl2,$frl3,$frl4,$frh1,$frh2,$frh3,$frh4);
 
-$list=shift @ARGV;
-open(LIST,$list)||die();
+my ($pdbfile,$filename);
+my ($lightchain, $heavychain);
+my ($nreslight,$ncyslight);
+my ($nresheavy,$ncysheavy);
+my ($lightseq,$heavyseq);
+my ($l1,$l2,$l3,$h1,$h2,$h3);
+
+my (@newnumberfrl1, @newnumberfrl2, @newnumberfrl3, $newnumberfrl4, @newnumberl1, @newnumberl2, @newnumberl3);
+my (@newnumberfrh1, @newnumberfrh2, @newnumberfrh3, $newnumberfrh4, @newnumberh1, @newnumberh2, @newnumberh3);
+
+my ($heavyseq_first, $heavyseq_second);
+my ($lightseq_first, $lightseq_second);
+
+my $len;
+
+
+my $list=shift @ARGV;
+open(LIST,"<$list")||die "E: Could not open '$list'. $!";
 
 &initialize;
 
@@ -41,54 +64,58 @@ while($pdbfile ne ''){
 
 sub initialize{
 	#get the pdbfilename and the chain ID's 
-	$line=<LIST>;
-	chop($line);
-	@fileandchains=split(/ +/,$line);
-	$pdbfile=$fileandchains[0];
-	$chains=$fileandchains[1];
-	@array=split(/:/,$chains);
-	$lightchain=substr($array[0],0,1);
-	$heavychain=substr($array[0],1,1);
-	$nreslight=$ncyslight=0;
-	$nresheavy=$ncysheavy=0;
-	$lightseq=$heavyseq=$l1=$l2=$l3=$h1=$h2=$h3='';
+	my $line=<LIST>;
+	if (defined($line)) {
+		chomp($line);
+		my @fileandchains=split(/ +/,$line);
+		$pdbfile=$fileandchains[0];
+		my $chains=$fileandchains[1];
+		my @array=split(/:/,$chains);
+		$lightchain=substr($array[0],0,1);
+		$heavychain=substr($array[0],1,1);
+		$nreslight=$ncyslight=0;
+		$nresheavy=$ncysheavy=0;
+		$lightseq=$heavyseq=$l1=$l2=$l3=$h1=$h2=$h3='';
+	} else {
+		# terminates the execution
+		$pdbfile="";
+	}
 }
 
-sub readpdbfile{
+sub readpdbfile {
 	#read the actual pdb file and then identify the light and the heavy chain sequence.
 	$filename=$pdbfile.".pdb";
 
 	#$filename = $pdbfile.".ent" if !(-e $filename);
 
-	if(-e $filename){
-
-	}else{
+	unless( -e $filename){
 		print "No PDB $filename\n";
 		exit;
 	}
 
 
-	open(PDBFILE,$filename)||die();
-	open(CHOTHIALIGHT,">$pdbfile\_chothia.light");
-	open(CHOTHIAHEAVY,">$pdbfile\_chothia.heavy");
-	$line=<PDBFILE>;
+	open(PDBFILE,"<$filename") or die("Could not open pdfile '$filename'. $!");
+	open(CHOTHIALIGHT,">$pdbfile\_chothia.light") or die ("Could not create cothia-numbered light chain at '$pdbfile\_chothia.light'. $!");
+	open(CHOTHIAHEAVY,">$pdbfile\_chothia.heavy") or die ("Could not create cothia-numbered heavy chain at '$pdbfile\_chothia.heavy'. $!");
+	my $line=<PDBFILE>;
 	chop($line);
 
 	while($line ne ''){
-		($identifier,$atomno,$atom,$residue,$chain,$residueno,@junk)=split(/ +/,$line);
+		my ($identifier,$atomno,$atom,$residue,$chain,$residueno,@junk)=split(/ +/,$line);
 
 		$identifier = substr($line,0,6);
 		$atomno = substr($line,6,5);
 		$atom = substr($line,12,4);
-		$alt_loc = substr($line,16,1);
+		my $alt_loc = substr($line,16,1);
 		$residue = substr($line,17,3);
 		$chain = substr($line,21,1);
 		$residueno = substr($line,22,4);
-		$insert_code=substr($line,26,1);
-		$x = substr($line,30,8);
-		$y = substr($line,38,8);
-		$z = substr($line,46,8);
+		my $insert_code=substr($line,26,1);
+		my $x = substr($line,30,8);
+		my $y = substr($line,38,8);
+		my $z = substr($line,46,8);
 
+		my ($old_residueno,$old_insert_code,$old_alt_loc)="";
 		if($identifier =~ "ATOM" and $atom =~ "CA"){
 			if($chain eq $lightchain){
 				$lightseq=$lightseq.$threetoone{$residue}unless(   ($old_residueno eq $residueno) and ($old_alt_loc ne $alt_loc)  and ($old_insert_code eq $insert_code)  );
@@ -104,13 +131,17 @@ sub readpdbfile{
 		}
 
 		$line=<PDBFILE>;
-		chop($line);
+		if (defined($line)) {
+			chomp($line);
+		} else {
+			$line="";
+		}
 	}
 
 	### Split a sequence into two parts ###
 	if(length($lightseq) > 120){
 		$lightseq_first  = substr($lightseq, 0, 60);
-		$lightseq_second = substr($lightseq, 50, 60);
+		$lightseq_second = substr($lightseq, 50, 70);
 	}else{
 		$lightseq_first  = substr($lightseq, 0, 60);
 		$lightseq_second = substr($lightseq, 50);
@@ -128,9 +159,10 @@ sub readpdbfile{
 sub findcdrs{
 	#*********L1***************************
 	# C[A-Z]{1,17}(WYL|WLQ|WFQ|WYQ|WYH|WVQ|WVR|WWQ|WVK|WYR|WLL|WFL|WVF|WIQ|WYR|WNQ|WHL|WHQ|WYM|WYY)
+	my $var;
 	$var = $lightseq_first =~/C[A-Z]{1,17}(WYL|WLQ|WFQ|WYQ|WYH|WVQ|WVR|WWQ|WVK|WYR|WLL|WFL|WVF|WIQ|WYR|WNQ|WHL|WYM|WYY)/;
 	if($var){
-		$temp=$&;
+		my $temp=$&;
 		$lenl1=length ($temp)-4;
 		$l1=substr($temp,1,$lenl1);
 	}
@@ -140,7 +172,7 @@ sub findcdrs{
 	# C[A-Z]{1,15}(F|V|S)G[A-Z](G|Y)
 	$var = $lightseq_second =~/C[A-Z]{1,15}(F|V|S)G[A-Z](G|Y)/;
 	if($var){
-		$temp=$&;
+		my $temp=$&;
 		$lenl3=length ($temp)-5;
 		$l3=substr($temp,1,$lenl3);
 
@@ -155,7 +187,7 @@ sub findcdrs{
 	# C[A-Z]{1,16}(W)(I|V|F|Y|A|M|L|N|G)(R|K|Q|V|N|C|G)(Q|K|H|E|L|R)
 	$var = $heavyseq_first =~/C[A-Z]{1,16}(W)(I|V|F|Y|A|M|L|N|G)(R|K|Q|V|N|C)(Q|K|H|E|L|R)/; 
 	if($var){
-		$temp=$&;
+		my $temp=$&;
 		$lenh1=length ($temp)-8;
 		$h1=substr($temp,4,$lenh1);
 	}
@@ -167,7 +199,7 @@ sub findcdrs{
 	if($pdbfile eq "1tqb"){
 		$var = $heavyseq_second =~/FTRGTDYWGQG/; # for 1ghf:"WAQG", for 3se8:"WCQG", for 3mug,3u1s,3u2s:more than 27
 		if($var){
-			$temp=$&;
+			my $temp=$&;
 			$lenh3=length ($temp)-7;
 			$h3=substr($temp,3,$lenh3);
 			$h1 = "GYTFTNYGMN";
@@ -177,7 +209,7 @@ sub findcdrs{
 		# C[A-Z]{1,33}(W)(G|A|C)[A-Z](S|G|R)
 		$var = $heavyseq_second =~/C[A-Z]{1,33}(W)(G|A|C)[A-Z](S|Q|G|R)/; # for 1ghf:"WAQG", for 3se8:"WCQG", for 3mug,3u1s,3u2s:more than 27
 		if($var){
-			$temp=$&;
+			my $temp=$&;
 			$lenh3=length ($temp)-7;
 			$h3=substr($temp,3,$lenh3);
 		}
@@ -187,26 +219,26 @@ sub findcdrs{
 
 	#***************************
 
-	$l1start= index($lightseq,$l1);
-	$l1end=$l1start+$lenl1-1;
-	$l2start=$l1end+16;
-	$l2end=$l2start+7-1;
+	my $l1start= index($lightseq,$l1);
+	my $l1end=$l1start+$lenl1-1;
+	my $l2start=$l1end+16;
+	my $l2end=$l2start+7-1;
 	#L211
 	#$l2end=$l2start+11-1;
-	$l3start= index($lightseq,$l3);
-	$l3end=$l3start+$lenl3-1;
-	$l2=substr($lightseq,$l2start,7);
+	my $l3start= index($lightseq,$l3);
+	my $l3end=$l3start+$lenl3-1;
+	my $l2=substr($lightseq,$l2start,7);
 	$lenl2=7;
 	#L211
 	#$lenl2=11;
 
-	$h1start = index($heavyseq,$h1);
-	$h1end=$h1start+$lenh1-1;
-	$h3start= index($heavyseq,$h3);
-	$h3end=$h3start+$lenh3-1;
+	my $h1start = index($heavyseq,$h1);
+	my $h1end=$h1start+$lenh1-1;
+	my $h3start= index($heavyseq,$h3);
+	my $h3end=$h3start+$lenh3-1;
 
-	$h2start=$h1end+15;
-	$h2end=$h3start-33;
+	my $h2start=$h1end+15;
+	my $h2end=$h3start-33;
 
 	if($pdbfile eq "1MFE"){
 		$h2start = $h1end + 15 - 1;
@@ -238,7 +270,7 @@ sub findcdrs{
 	$lenfrh3=length($frh3);
 	$frh4=substr($heavyseq,$h3end+1,10);
 	$lenfrh4=length($frh4);
-	$seq1=$frh1.$h1.$frh2.$h2.$frh3.$h3;
+	my $seq1=$frh1.$h1.$frh2.$h2.$frh3.$h3; # not used again
 
 	print "$filename\t$frl1 - \"$l1\" - $frl2 - \"$l2\" - $frl3 - \"$l3\" - $frl4\n";
 	print "$filename\t$frh1 - \"$h1\" - $frh2 - \"$h2\" - $frh3 - \"$h3\" - $frh4\n";
@@ -246,6 +278,7 @@ sub findcdrs{
 
 
 sub renumbercdrs{
+	my @string;
 	$string[1]=$newnumberfrl1[$lenfrl1];
 	$string[2]=$newnumberl1[$lenl1];
 	$string[3]=$newnumberfrl2[$lenfrl2];
@@ -254,11 +287,11 @@ sub renumbercdrs{
 	$string[6]=$newnumberl3[$lenl3];
 	$string[7]=$newnumberfrl4;
 
-	for($i=1;$i<=7;$i++){
-		@array=split(/,/,$string[$i]);
-		$nelements=@array;
+	for(my $i=1;$i<=7;$i++){
+		my @array=split(/,/,$string[$i]);
+		my $nelements=@array;
 
-		for($j=0;$j <$nelements;$j++){
+		for(my $j=0;$j <$nelements;$j++){
 			print CHOTHIALIGHT "$array[$j]\n";
 		}
 
@@ -272,11 +305,11 @@ sub renumbercdrs{
 	$string[6]=$newnumberh3[$lenh3];
 	$string[7]=$newnumberfrh4;
 
-	for($i=1;$i<=7;$i++){
-		@array=split(/,/,$string[$i]);
-		$nelements=@array;
+	for(my $i=1;$i<=7;$i++){
+		my @array=split(/,/,$string[$i]);
+		my $nelements=@array;
 
-		for($j=0;$j <$nelements;$j++){
+		for(my $j=0;$j <$nelements;$j++){
 			print CHOTHIAHEAVY "$array[$j]\n";
 		}
 	}
@@ -415,24 +448,24 @@ sub assignnumbering{
 
 
 sub checknumbering{
-	$error="NOK";
-	$error1=$error2=$error3=$error4=$error5=0;
+	my $error="NOK";
+	my ($error1,$error2,$error3,$error4,$error5)=(0,0,0,0,0);
 
-	$val1=substr($frh1,-22,1);
-	$val2=substr($frh1,-20,1);
-	$val3=substr($frh1,-11,1);
-	$val4=substr($frh1,-6,1);
-	$val5=substr($frh1,-5,1);
+	my $val1=substr($frh1,-22,1);
+	my $val2=substr($frh1,-20,1);
+	my $val3=substr($frh1,-11,1);
+	my $val4=substr($frh1,-6,1);
+	my $val5=substr($frh1,-5,1);
 
-	$val6=substr($frh1,-19,1);
-	$val7=substr($frh1,-18,1);
-	$val8=substr($frh1,-17,1);
+	my $val6=substr($frh1,-19,1);
+	my $val7=substr($frh1,-18,1);
+	my $val8=substr($frh1,-17,1);
 
-	$h18 = substr($frh1,-8,1);
-	$string1="$val2$val7$val8";
-	$string2="$val2$val6$val7";
+	my $h18 = substr($frh1,-8,1);
+	my $string1="$val2$val7$val8";
+	my $string2="$val2$val6$val7";
 
-	$type = "unknown";
+	my $type = "unknown";
 	$type = "type1" if($string1 eq "EGP");
 	$type = "type2" if($string1 eq "EGG");
 	$type = "type3" if ($string2 =~ /Q[A-O,Q-Z]G/);
@@ -448,6 +481,7 @@ sub checknumbering{
 	#print "$pdbfile\t$val1\t$val2\t$val3\t$val4\t$val5\t$error\t$lenfrh1\t$frh1\t$lenfrh3\t$frh3\n";
 	#print "DK:$pdbfile\t$lenfrh3\t$frh3\n";
 
+	my $krithi=0; # not used anywhere else
 	if($krithi){
 		$val1=substr($frl1,-20,1);
 		$val2=substr($frl1,-18,1);


### PR DESCRIPTION
To have worked on this patch was a bit of a mistake - it took an hour or two with no immediate scientific benefits. Well, I found a bug in the split of the light sequence into a first and second part, but, well. 

What the patch does is that is ensures that there are no typos in the naming of variables and that a local change does not affect a variable of the same name elsewhere. The Perl helper to ensure this is to introduce "use strict;". A program will not run until the last undeclared variable has been fixed. Thus, the addition of "use strict;" gives some extra piece of mind. Just, I had not anticipated upfront that there are so many variables in this short script to be  declared, so I must admit.

There are no functional changes in the second commit (the first is addressed by https://github.com/RosettaCommons/tools/pull/16), with the exception of a fix of an inconsistency with how the heavy chain is treated. It becomes evident with a poo at the context in the "<code>if ( length > 120 )</code>" in the source code:

<pre>
 $lightseq_first = substr($lightseq, 0, 60);
- $lightseq_second = substr($lightseq, 50, 60);
+ $lightseq_second = substr($lightseq, 50, 70);
</pre>
