### PR TITLE
antibody.py: default H1_end

### DIFF
--- a/antibody/antibody.py
+++ b/antibody/antibody.py
@@ -489,6 +489,7 @@ def IdentifyCDRs(light_chain, heavy_chain):
             FR_L1 = light_chain[len_FR_L1:L1_start]
     else:
         print "L1 detected: False"
+        L1_end = -16
 
     light_second = light_chain[L1_end+16+7:L1_end+16+7+80] if len(light_chain) > 130 else light_chain[L1_end+16+7:]
 


### PR DESCRIPTION
If the pattern for H1 does not match, the whole sequence space shall be used to determine a match for H3. Today, if a V region is complete only on the C-terminus, antibody.py complains about the use of an undefined variable. For L1 the situation is anologous.

I found this now while working with data from immune repertoire analyses with next-generation sequencers which, for our local setup, tend to lack the N-terminal Fv region, so the pattern for H1 does not match.
