### PR TITLE
Generalize around $ROSETTA_TOOLS

### DIFF
--- a/rna_tools/INSTALL
+++ b/rna_tools/INSTALL
@@ -1,4 +1,9 @@
-export RNA_TOOLS=$ROSETTA_TOOLS/rna_tools/
+# If ROSETTA_TOOLS is set, then use it; else assume $ROSETTA/tools
+if [ -z ${ROSETTA_TOOLS+x} ]
+  export RNA_TOOLS=$ROSETTA/tools/rna_tools/
+else
+  export RNA_TOOLS=$ROSETTA_TOOLS/rna_tools/
+fi
 
 #Runs the commands
 python $RNA_TOOLS/sym_link.py


### PR DESCRIPTION
Don't assume the (rarely used elsewhere) variable $ROSETTA_TOOLS is set; if it's unset, assume $ROSETTA/tools
