### PR TITLE
XSD to md script

### DIFF
--- a/doc_tools/xsd_to_doc_fragments.py
+++ b/doc_tools/xsd_to_doc_fragments.py
@@ -364,7 +364,10 @@ def main( xsdfile, outdir ):
 if __name__ == "__main__":
 
     if len(sys.argv) != 3:
+        print
         print "ERROR: Usage: ./create_rosetta_scripts_docs.py <xsd file> <directory to write docs to>"
+        print
+        print __doc__
         sys.exit()
 
     main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Add a script that takes the RosettaScripts XSD file (output by `-parser::output_schema`) and converts it to Markdown documentation fragments, which can be transcluded into the Rosetta documentation with the Gollum `[[include:filename]]` syntax.

Due to the cross-repository nature of the thing, this script will need to be (manually) run occasionally, particularly when new RosettaScript objects are added.