### PR TITLE
Add the nanobody 4w6w to the outlier_list

### DIFF
--- a/antibody/info/outlier_list
+++ b/antibody/info/outlier_list
@@ -3981,10 +3981,10 @@ pdb8fab_chothia.pdb L2 false
 pdb8fab_chothia.pdb L3 false
 pdb8fab_chothia.pdb H1 false
 pdb8fab_chothia.pdb H2 false
-pdb4w6w_chothia.pdb FRL true
-pdb4w6w_chothia.pdb FRH true
-pdb4w6w_chothia.pdb L1 true
-pdb4w6w_chothia.pdb L2 true
-pdb4w6w_chothia.pdb L3 true
-pdb4w6w_chothia.pdb H1 true
+pdb4w6w_chothia.pdb FRL false
+pdb4w6w_chothia.pdb FRH false
+pdb4w6w_chothia.pdb L1 false
+pdb4w6w_chothia.pdb L2 false
+pdb4w6w_chothia.pdb L3 false
+pdb4w6w_chothia.pdb H1 false
 pdb4w6w_chothia.pdb H2 true


### PR DESCRIPTION
Add the nanobody 4w6w to the outlier_list so that it will be black listed from being used as a template in antibody.cc.  We found that this template (nano body) was problematic because and causes antibody.cc run to fail because it was trying to graft a H2 loop from this template that had a cysteine that is part of a disulfide with other parts of the non-grafted segment of the nanobody framework.  We find that in previous versions of the the PDB (before 2012), this template (4w6w) would not be selected and so antibody.cc would run successfully.