### PR TITLE
Danpf/fix install deps

### DIFF
--- a/fragment_tools/install_dependencies.pl
+++ b/fragment_tools/install_dependencies.pl
@@ -305,7 +305,7 @@ if (!$skip_nr && ($overwrite || !-s "$datdir/nr_pfilt.pal")) {
 
 	if (!-s "$datdir/nr_pfilt") {
 		print "Generating nr_pfilt fasta. Be very very patient ......\n";
-		$cmd = "$Bin/psipred/bin/pfilt $datdir/nr > $datdir/nr_pfilt";
+		my $cmd = "$Bin/psipred/bin/pfilt $datdir/nr > $datdir/nr_pfilt";
 		print $cmd;
 		(system($cmd) == 0) or die "ERROR! $cmd failed.\n";
 	}


### PR DESCRIPTION
Install dependencies fails because update_blastdb.pl doesn't exist anymore.
also added a little bit of checkpointing at pfilt stage

This works locally for me, but this will be tested via scientific benchmarks in the next day or so, so if it doesn't work I will revert this.