### PR TITLE
Add boost_submod to tool directory scripts.

### DIFF
--- a/clang_ast_transform/add_serialization_code.sh
+++ b/clang_ast_transform/add_serialization_code.sh
@@ -11,6 +11,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=add_serialization_code $OUT_DIR $FILE
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem external/boost_1_55_0/ \
+	-isystem external/boost_submod/ \
 	-isystem external/ \
 	-isystem external/include/ \
 	-isystem external/dbio/ \
@@ -27,7 +28,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=add_serialization_code $OUT_DIR $FILE
 	-Isrc/platform/linux/64/clang \
 	-Isrc/platform/linux/64 \
 	-Isrc/platform/linux \
-	-Iexternal/boost_1_55_0 \
 	-Iexternal/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/code_qual_check_file.sh
+++ b/clang_ast_transform/code_qual_check_file.sh
@@ -10,6 +10,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=code_quality_check /tmp/ $FILE -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem external/boost_1_55_0/ \
+	-isystem external/boost_submod/ \
 	-isystem external/ \
 	-isystem external/include/ \
 	-isystem external/dbio/ \
@@ -26,7 +27,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=code_quality_check /tmp/ $FILE -- \
 	-Isrc/platform/linux/64/clang \
 	-Isrc/platform/linux/64 \
 	-Isrc/platform/linux \
-	-Iexternal/boost_1_55_0 \
 	-Iexternal/dbio \
 	-I/usr/include \
 	-I/usr/local/include 

--- a/clang_ast_transform/debug_run_rrt_matchers_on_file.sh
+++ b/clang_ast_transform/debug_run_rrt_matchers_on_file.sh
@@ -36,6 +36,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=$MATCHERS $FILE -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem $SOURCE/external/boost_1_55_0/ \
+	-isystem $SOURCE/external/boost_submod/ \
 	-isystem $SOURCE/external \
 	-isystem $SOURCE/external/include/ \
 	-isystem $SOURCE/external/dbio/ \
@@ -53,7 +54,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=$MATCHERS $FILE -- \
 	-I$SOURCE/src/platform/linux/64/clang \
 	-I$SOURCE/src/platform/linux/64 \
 	-I$SOURCE/src/platform/linux \
-	-I$SOURCE/external/boost_1_55_0 \
 	-I$SOURCE/external/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/dump_ast.sh
+++ b/clang_ast_transform/dump_ast.sh
@@ -24,6 +24,7 @@ $CLANG_BUILD/bin/clang-check -ast-dump $1 -ast-dump-filter=$2 -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem $ROSETTA_SOURCE/external/boost_1_55_0/ \
+	-isystem $ROSETTA_SOURCE/external/boost_submod/ \
 	-isystem $ROSETTA_SOURCE/external/ \
 	-isystem $ROSETTA_SOURCE/external/include/ \
 	-isystem $ROSETTA_SOURCE/external/dbio/ \
@@ -41,7 +42,6 @@ $CLANG_BUILD/bin/clang-check -ast-dump $1 -ast-dump-filter=$2 -- \
 	-I$ROSETTA_SOURCE/src/platform/linux/64/clang \
 	-I$ROSETTA_SOURCE/src/platform/linux/64 \
 	-I$ROSETTA_SOURCE/src/platform/linux \
-	-I$ROSETTA_SOURCE/external/boost_1_55_0 \
 	-I$ROSETTA_SOURCE/external/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/emit_ast.sh
+++ b/clang_ast_transform/emit_ast.sh
@@ -4,6 +4,7 @@ SRC=/local/luki/clang/llvm
 $BD/bin/clang++ $1 -emit-ast -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem external/boost_1_55_0/ \
+	-isystem external/boost_submod/ \
 	-isystem external/ \
 	-isystem external/include/ \
 	-isystem external/dbio/ \
@@ -19,7 +20,6 @@ $BD/bin/clang++ $1 -emit-ast -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-Isrc/platform/linux/64/clang \
 	-Isrc/platform/linux/64 \
 	-Isrc/platform/linux \
-	-Iexternal/boost_1_55_0 \
 	-Iexternal/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/extract_serialization_data.sh
+++ b/clang_ast_transform/extract_serialization_data.sh
@@ -30,6 +30,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=find_record_decl,find_constructor_dec
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem $SOURCE/external/boost_1_55_0/ \
+	-isystem $SOURCE/external/boost_submod/ \
 	-isystem $SOURCE/external/ \
 	-isystem $SOURCE/external/include/ \
 	-isystem $SOURCE/external/dbio/ \
@@ -48,7 +49,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=find_record_decl,find_constructor_dec
 	-I$SOURCE/src/platform/linux/64/clang \
 	-I$SOURCE/src/platform/linux/64 \
 	-I$SOURCE/src/platform/linux \
-	-I$SOURCE/external/boost_1_55_0 \
 	-I$SOURCE/external/dbio \
 	-I$SOURCE/external/libxml2/include/ \
 	-I/usr/include \

--- a/clang_ast_transform/rewrite_file.sh
+++ b/clang_ast_transform/rewrite_file.sh
@@ -11,6 +11,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=rewrite -verbose $OUT_DIR $FILE -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem external/boost_1_55_0/ \
+	-isystem external/boost_submod/ \
 	-isystem external/ \
 	-isystem external/include/ \
 	-isystem external/dbio/ \
@@ -27,7 +28,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=rewrite -verbose $OUT_DIR $FILE -- \
 	-Isrc/platform/linux/64/clang \
 	-Isrc/platform/linux/64 \
 	-Isrc/platform/linux \
-	-Iexternal/boost_1_55_0 \
 	-Iexternal/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/rewrite_file_test.sh
+++ b/clang_ast_transform/rewrite_file_test.sh
@@ -13,6 +13,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=rewrite $OUT_DIR $FILE -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem external/boost_1_55_0/ \
+	-isystem external/boost_submod/ \
 	-isystem external/ \
 	-isystem external/include/ \
 	-isystem external/dbio/ \
@@ -29,7 +30,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=rewrite $OUT_DIR $FILE -- \
 	-Isrc/platform/linux/64/clang \
 	-Isrc/platform/linux/64 \
 	-Isrc/platform/linux \
-	-Iexternal/boost_1_55_0 \
 	-Iexternal/dbio \
 	-Iexternal/cxxtest/ \
 	-Itest/ \

--- a/clang_ast_transform/rewrite_test.sh
+++ b/clang_ast_transform/rewrite_test.sh
@@ -9,6 +9,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=rewrite $1 -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem external/boost_1_55_0/ \
+	-isystem external/boost_submod/ \
 	-isystem external/ \
 	-isystem external/include/ \
 	-isystem external/dbio/ \
@@ -24,7 +25,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=rewrite $1 -- \
 	-Isrc/platform/linux/64/clang \
 	-Isrc/platform/linux/64 \
 	-Isrc/platform/linux \
-	-Iexternal/boost_1_55_0 \
 	-Iexternal/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/run.sh
+++ b/clang_ast_transform/run.sh
@@ -8,6 +8,7 @@ $CLANG_BIN/rosetta-refactor-tool ${*:2} $FILE -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem $SOURCE/external/boost_1_55_0/ \
+	-isystem $SOURCE/external/boost_submod/ \
 	-isystem $SOURCE/external/ \
 	-isystem $SOURCE/external/include/ \
 	-isystem $SOURCE/external/dbio/ \
@@ -24,7 +25,6 @@ $CLANG_BIN/rosetta-refactor-tool ${*:2} $FILE -- \
 	-I$SOURCE/src/platform/linux/64/clang \
 	-I$SOURCE/src/platform/linux/64 \
 	-I$SOURCE/src/platform/linux \
-	-I$SOURCE/external/boost_1_55_0 \
 	-I$SOURCE/external/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/run_rrt_matchers_on_file.sh
+++ b/clang_ast_transform/run_rrt_matchers_on_file.sh
@@ -36,6 +36,7 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=$MATCHERS $FILE -- \
 	clang++ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS \
 	-std=c++11 \
 	-isystem $SOURCE/external/boost_1_55_0/ \
+	-isystem $SOURCE/external/boost_submod/ \
 	-isystem $SOURCE/external/ \
 	-isystem $SOURCE/external/include/ \
 	-isystem $SOURCE/external/dbio/ \
@@ -53,7 +54,6 @@ $CLANG_BIN/rosetta-refactor-tool -matchers=$MATCHERS $FILE -- \
 	-I$SOURCE/src/platform/linux/64/clang \
 	-I$SOURCE/src/platform/linux/64 \
 	-I$SOURCE/src/platform/linux \
-	-I$SOURCE/external/boost_1_55_0 \
 	-I$SOURCE/external/dbio \
 	-I/usr/include \
 	-I/usr/local/include

--- a/clang_ast_transform/run_serialization_validator_on_file.py
+++ b/clang_ast_transform/run_serialization_validator_on_file.py
@@ -68,6 +68,7 @@ if __name__ == "__main__" :
               "-ffor-scope " + \
               "-DEXIT_THROWS_EXCEPTION " + \
               "-isystem " + rosetta_source_dir + "/external/boost_1_55_0/ " + \
+              "-isystem " + rosetta_source_dir + "/external/boost_submod/ " + \
               "-isystem " + rosetta_source_dir + "/external/ " + \
               "-isystem " + rosetta_source_dir + "/external/include/ " + \
               "-isystem " + rosetta_source_dir + "/external/dbio/ " + \
@@ -85,7 +86,6 @@ if __name__ == "__main__" :
               "-I" + rosetta_source_dir + "/src/platform/linux/64/clang " + \
               "-I" + rosetta_source_dir + "/src/platform/linux/64 " + \
               "-I" + rosetta_source_dir + "/src/platform/linux " + \
-              "-I" + rosetta_source_dir + "/external/boost_1_55_0 " + \
               "-I" + rosetta_source_dir + "/external/dbio " + \
               "-I" + rosetta_source_dir + "/external/libxml2/include " + \
               "-I/usr/include " + \

--- a/python_cc_reader/test_compile.py
+++ b/python_cc_reader/test_compile.py
@@ -41,7 +41,7 @@ def central_compile_command() :
    # if your compiler doesn't support -S, you might see this error:
    # cc1plus: error: output filename specified twice
 
-   include_directories = " -I./ -I../external -I../external/include -Iplatform/" + os + "/" + nbits + "/gcc -Iplatform/" + os + "/" + nbits +  " -Iplatform/" + os + " -I../external/boost_1_55_0 -I/usr/local/include -I/usr/include/ -I../external/dbio -I../external/libxml2/include"
+   include_directories = " -I./ -I../external -I../external/include -Iplatform/" + os + "/" + nbits + "/gcc -Iplatform/" + os + "/" + nbits +  " -Iplatform/" + os + " -I../external/boost_1_55_0 -I../external/boost_submod -I/usr/local/include -I/usr/include/ -I../external/dbio -I../external/libxml2/include"
 
    generic_command = " -c -std=c++11 -pipe -ffor-scope -w -pedantic -Wno-long-long -O0 -ffloat-store -DPTR_MODERN -DPTR_STD" + include_directories
    return compiler, generic_command
@@ -53,7 +53,7 @@ def cxxtest_testgen_command() :
 
 
 def cxxtest_gcc_compile_command() :
-   return "g++ -c -isystem ../external/boost_1_55_0/boost/ -O0 -g -ggdb -ffloat-store -I../external/cxxtest -I../. -I../test -I../src -I../external -I../external/include -Iplatform/linux/64/gcc -Iplatform/linux/64 -Iplatform/linux -I../external/boost_1_55_0 -I../external/dbio -I/usr/local/include -I/usr/include -o "
+   return "g++ -c -isystem ../external/boost_1_55_0/ -isystem ../external/boost_submod/ -O0 -g -ggdb -ffloat-store -I../external/cxxtest -I../. -I../test -I../src -I../external -I../external/include -Iplatform/linux/64/gcc -Iplatform/linux/64 -Iplatform/linux -I../external/dbio -I/usr/local/include -I/usr/include -o "
 
 def cxxtest_test_compile( cxx_hh, verbose=False, id="" ) :
    out_log = "out.log"


### PR DESCRIPTION
To support full testing of RosettaCommons/main#4360, we need to have support/changes in the tools repo (for tests like the header only and serialization code quality tests, which use scripts in the tools directory which hard code the compiler include  paths.)

To support both current master and the new submodule approach, I've _added_ the boost_submod directory to the compilation command line in addition the the old boost_1_55_0 one. That should hopefully work for both versions, as nonexistant include directories should be ignored. (We can remove the old directory if/when we officially merge the submodule approach.)