### PR TITLE
Modifies SequenceProfile.py allow functionality for multiple chains w…

### DIFF
--- a/protein_tools/scripts/SequenceProfile.py
+++ b/protein_tools/scripts/SequenceProfile.py
@@ -7,6 +7,7 @@
 # (c) addressed to University of Washington CoMotion, email: license@uw.edu.
 
 ## Authors: Florian Richter
+## Modified by Nick Randolph (Jan 2021)
 
 ################################################################################################
 # Sequence profile for a list of structures vs a template


### PR DESCRIPTION
…ithout

having to separate into different pdb files. Now just include the "-c ChainID"
flag, where ChainID is the chain ID of the chain you'd like to sequence.
Additionally, script now allows for gaps in residue number and modifies output
file by including both Rosetta residue numbers and pdb residue numbers.