### PR TITLE
Fix beautify_changed_files_in_branch.py with respect to moved files.

### DIFF
--- a/python_cc_reader/beautify_changed_files_in_branch.py
+++ b/python_cc_reader/beautify_changed_files_in_branch.py
@@ -26,7 +26,7 @@ def parse_changedlist(rev_to_diff_against):
     # --relative -- make the name listing relative to the current subdirectory.
     bash_command = [ "git", "diff", "--relative", "--name-status", rev_to_diff_against, "HEAD" ]
     command_output = subprocess.Popen(bash_command, stdout=subprocess.PIPE).communicate()[0].decode('ascii')
-    print("Initial list\n", command_output)
+    #print("Initial list\n", command_output)
 
     file_list = []
     for line in command_output.splitlines():

--- a/python_cc_reader/beautify_compiled_files_w_fork.py
+++ b/python_cc_reader/beautify_compiled_files_w_fork.py
@@ -1,3 +1,6 @@
+
+from __future__ import print_function
+
 from python_cc_reader.utility import fork_manager
 from python_cc_reader.external.blargs import blargs
 from python_cc_reader.beauty import beautifier
@@ -6,7 +9,7 @@ import sys, os
 
 from python_cc_reader.cpp_parser.code_utilities import *
 
-# This script is meant to be run from either the Rosetta/main/source/src/ or 
+# This script is meant to be run from either the Rosetta/main/source/src/ or
 # the Rosetta/main/source/test/ directories. It reads the scons .settings
 # files to determine what files are compiled, and then runs the beautifier
 # on all of them.  By default, the script does NOT modify the input files, but
@@ -72,7 +75,7 @@ def files_to_beautify() :
         return files_in_src_to_beautify()
     elif lastdir == "test" :
         return files_in_test_to_beautify()
-    
+
 
 def files_in_src_to_beautify() :
     includes = scan_compilable_files()


### PR DESCRIPTION
Update parsing of git output to better accomodate for the multiple-names-in-line format for moved files.